### PR TITLE
Move splitspeeds/did code from splitspeeds to DID

### DIFF
--- a/DID.as
+++ b/DID.as
@@ -133,6 +133,12 @@ namespace DID {
         registerLaneProviderAddon(CurrenCheckpointHandler());
 #endif
 
+
+#if DEPENDENCY_SPLITSPEEDS
+	DID::registerLaneProviderAddon(SplitSpeedsDiffProvider());
+	DID::registerLaneProviderAddon(SplitSpeedsSpeedProvider());
+#endif
+
     // fill all our slots with empty info to prevent NPE on first frame running
     for (uint i = 0; i < 8; i++) {
         @lanes[i] = getInfoText("DID/NullProvider", i);

--- a/DIDAddonsSplitSpeeds.as
+++ b/DIDAddonsSplitSpeeds.as
@@ -1,0 +1,40 @@
+#if DEPENDENCY_SPLITSPEEDS
+namespace DID {
+    vec4 DIDColor = vec4(1,0,0,1);
+    string DIDTextTotal = "";
+    string DIDTextDiff = "";
+
+    class SplitSpeedsSpeedProvider : DID::LaneProvider {
+        DID::LaneProviderSettings@ getProviderSetup() {
+            DID::LaneProviderSettings settings;
+            settings.author = "RuteNL";
+            settings.internalName = "SplitSpeeds/TotalSpeed";
+            settings.friendlyName = "Split Speeds (Current)";
+            return settings;
+        }
+
+        DID::LaneConfig@ getLaneConfig(DID::LaneConfig@ &in defaults) {
+            DID::LaneConfig c = defaults;
+            c.content = SplitSpeeds::visible ? SplitSpeeds::speedText : "";
+            return c;
+        }
+    }
+
+    class SplitSpeedsDiffProvider : DID::LaneProvider {
+        DID::LaneProviderSettings@ getProviderSetup() {
+            DID::LaneProviderSettings settings;
+            settings.author = "RuteNL";
+            settings.internalName = "SplitSpeeds/SpeedDelta";
+            settings.friendlyName = "Split Speeds (Difference)";
+            return settings;
+        }
+
+        DID::LaneConfig@ getLaneConfig(DID::LaneConfig@ &in defaults) {
+            DID::LaneConfig c = defaults;
+            c.content = (SplitSpeeds::visible && SplitSpeeds::hasDifference) ? SplitSpeeds::differenceText : "";
+            c.color = SplitSpeeds::currentColour;
+            return c;
+        }
+    }
+}
+#endif

--- a/info.toml
+++ b/info.toml
@@ -7,7 +7,7 @@ siteid = 311
 
 [script]
 dependencies = ["Camera", "VehicleState"]
-optional_dependencies = ["MLHook", "MLFeedRaceData"]
+optional_dependencies = ["MLHook", "MLFeedRaceData", "SplitSpeeds"]
 exports = [ "DID_Export.as" ]
 shared_exports = [ "DID_ExportShared.as" ]
 module = "DID"


### PR DESCRIPTION
I added exports to splitspeeds (https://github.com/RuurdBijlsma/tm-split-speeds/commit/96145c0e9245d028c23e58295574b8a1af0365fb) and removed the did-specific code from splitspeeds. This is imo a cleaner way of integrating the two plugins

I'll wait a bit before publishing this to openplanet, so you have the opportunity to update if you want. This is the newest version of the plugin so you can test with it: 
[SplitSpeeds.zip](https://github.com/sylae/DiegeticInfoDisplay/files/10606693/SplitSpeeds.zip)
