### PR TITLE
Add no-respawn timer and no-respawn splits lane providers

### DIFF
--- a/DID.as
+++ b/DID.as
@@ -130,6 +130,8 @@ namespace DID {
         registerLaneProviderAddon(CurrentLapHandler());
         registerLaneProviderAddon(CurrentLapAlwaysHandler());
         registerLaneProviderAddon(CurrenCheckpointHandler());
+        registerLaneProviderAddon(NoRespawnTimeHandler());
+        registerLaneProviderAddon(NoRespawnSplitsHandler());
 #endif
 
 

--- a/DIDAddonsMLFeed.as
+++ b/DIDAddonsMLFeed.as
@@ -1,146 +1,196 @@
 #if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
 namespace DID {
+    const MLFeed::PlayerCpInfo_V3@ plf = null;
+    const MLFeed::HookRaceStatsEventsBase_V3@ mlf = null;
 
-        class RaceTimeHandler : LaneProvider {
-            LaneProviderSettings@ getProviderSetup() {
-                LaneProviderSettings settings;
-                settings.author = "MisfitMaid";
-                settings.internalName = "DID/RaceTime";
-                settings.friendlyName = "Current race time";
-                return settings;
-            }
+    void CacheLocalPlayerCoro() {
+        @mlf = MLFeed::GetRaceData_V3();
+        while (true) {
+            yield();
+            if (GetApp().CurrentPlayground is null)
+                @plf = null;
+            else if (plf is null)
+                @plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
+        }
+    }
+    Meta::PluginCoroutine@ MLFeedCacheLocalPlayerCoro = startnew(CacheLocalPlayerCoro);
 
-            LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
-                LaneConfig c = defaults;
-                const MLFeed::HookRaceStatsEventsBase_V3@ mlf = MLFeed::GetRaceData_V3();
-                const MLFeed::PlayerCpInfo_V3@ plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
-                if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+    class RaceTimeHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "MisfitMaid";
+            settings.internalName = "DID/RaceTime";
+            settings.friendlyName = "Current race time";
+            return settings;
+        }
+
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+            c.content = (plf.CurrentRaceTime < 0) ? Time::Format(0) : Time::Format(plf.CurrentRaceTime);
+            return c;
+        }
+    }
+
+    class RaceTimeSplitHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "MisfitMaid";
+            settings.internalName = "DID/RaceTimeSplit";
+            settings.friendlyName = "Current race time (with freezes on checkpoint splits)";
+            return settings;
+        }
+
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+
+            if (plf.cpCount > 0 && (plf.CurrentRaceTime - plf.LastCpTime) < int(deltaTimeDuration)) {
+                c.content = Time::Format(plf.lastCpTime);
+            } else {
                 c.content = (plf.CurrentRaceTime < 0) ? Time::Format(0) : Time::Format(plf.CurrentRaceTime);
-                return c;
             }
+            return c;
+        }
+    }
+
+    void PrepareConfigCpSplitsTime(int cpMs, LaneConfig@ c) {
+        if (cpMs < 0) {
+            c.content = "+" + Time::Format(cpMs*-1, true, false);
+        } else {
+            c.content = "-" + Time::Format(cpMs, true, false);
         }
 
-        class RaceTimeSplitHandler : LaneProvider {
-            LaneProviderSettings@ getProviderSetup() {
-                LaneProviderSettings settings;
-                settings.author = "MisfitMaid";
-                settings.internalName = "DID/RaceTimeSplit";
-                settings.friendlyName = "Current race time (with freezes on checkpoint splits)";
-                return settings;
-            }
-
-            LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
-                LaneConfig c = defaults;
-                const MLFeed::HookRaceStatsEventsBase_V3@ mlf = MLFeed::GetRaceData_V3();
-                const MLFeed::PlayerCpInfo_V3@ plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
-                if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
-
-                if (plf.cpCount > 0 && (plf.CurrentRaceTime - plf.LastCpTime) < int(deltaTimeDuration)) {
-                    c.content = Time::Format(plf.lastCpTime);
-                } else {
-                    c.content = (plf.CurrentRaceTime < 0) ? Time::Format(0) : Time::Format(plf.CurrentRaceTime);
-                }
-                return c;
+        if (deltaTimeColors) {
+            if (cpMs < 0) {
+                c.color = vec4(.869, 0.117, 0.117, .784);
+            } else {
+                c.color = vec4(0, .123, .822, .75);
             }
         }
+    }
 
-        class SplitDeltaHandler : LaneProvider {
-            LaneProviderSettings@ getProviderSetup() {
-                LaneProviderSettings settings;
-                settings.author = "MisfitMaid";
-                settings.internalName = "DID/SplitDelta";
-                settings.friendlyName = "Checkpoint delta splits verus personal best";
-                return settings;
-            }
-
-            LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
-                LaneConfig c = defaults;
-                const MLFeed::HookRaceStatsEventsBase_V3@ mlf = MLFeed::GetRaceData_V3();
-                const MLFeed::PlayerCpInfo_V3@ plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
-                if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
-
-                int cpMs;
-                if (plf.cpCount > 0 && (plf.CurrentRaceTime - plf.LastCpTime) < int(deltaTimeDuration) && plf.BestRaceTimes.Length > uint(plf.cpCount)) {
-                    cpMs = plf.BestRaceTimes[plf.cpCount-1] - plf.LastCpTime;
-                    if (cpMs < 0) {
-                        c.content = "+" + Time::Format(cpMs*-1, true, false);
-                    } else {
-                        c.content = "-" + Time::Format(cpMs, true, false);
-                    }
-                } else {
-                    c.content = "";
-                }
-
-                if (deltaTimeColors) {
-                    if (cpMs < 0) {
-                        c.color = vec4(.869, 0.117, 0.117, .784);
-                    } else {
-                        c.color = vec4(0, .123, .822, .75);
-                    }
-                }
-                return c;
-            }
+    class SplitDeltaHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "MisfitMaid";
+            settings.internalName = "DID/SplitDelta";
+            settings.friendlyName = "Checkpoint delta splits verus personal best";
+            return settings;
         }
 
-        class CurrentLapHandler : LaneProvider {
-            LaneProviderSettings@ getProviderSetup() {
-                LaneProviderSettings settings;
-                settings.author = "MisfitMaid";
-                settings.internalName = "DID/CurrentLap";
-                settings.friendlyName = "Lap counter (if multilap)";
-                return settings;
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+
+            int cpMs;
+            if (plf.cpCount > 0 && (plf.CurrentRaceTime - plf.LastCpTime) < int(deltaTimeDuration) && plf.BestRaceTimes.Length > uint(plf.cpCount)) {
+                cpMs = plf.BestRaceTimes[plf.cpCount-1] - plf.LastCpTime;
+                PrepareConfigCpSplitsTime(cpMs, c);
+            } else {
+                c.content = "";
             }
 
-            LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
-                LaneConfig c = defaults;
-                const MLFeed::HookRaceStatsEventsBase_V3@ mlf = MLFeed::GetRaceData_V3();
-                const MLFeed::PlayerCpInfo_V3@ plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
-                if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+            return c;
+        }
+    }
 
-                c.content = getTotLaps() == 1 ? "" : Text::Format("%d", (plf.CpCount / (mlf.CpCount+1))+1)+" / "+Text::Format("%d", mlf.LapCount);
-                return c;
-            }
+    class CurrentLapHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "MisfitMaid";
+            settings.internalName = "DID/CurrentLap";
+            settings.friendlyName = "Lap counter (if multilap)";
+            return settings;
         }
 
-        class CurrentLapAlwaysHandler : LaneProvider {
-            LaneProviderSettings@ getProviderSetup() {
-                LaneProviderSettings settings;
-                settings.author = "MisfitMaid";
-                settings.internalName = "DID/CurrentLapAlways";
-                settings.friendlyName = "Lap counter (always)";
-                return settings;
-            }
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
 
-            LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
-                LaneConfig c = defaults;
-                const MLFeed::HookRaceStatsEventsBase_V3@ mlf = MLFeed::GetRaceData_V3();
-                const MLFeed::PlayerCpInfo_V3@ plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
-                if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+            c.content = getTotLaps() == 1 ? "" : Text::Format("%d", (plf.CpCount / (mlf.CpCount+1))+1)+" / "+Text::Format("%d", mlf.LapCount);
+            return c;
+        }
+    }
 
-                c.content = Text::Format("%d", (plf.CpCount / (mlf.CpCount+1))+1)+" / "+Text::Format("%d", mlf.LapCount);
-                return c;
-            }
+    class CurrentLapAlwaysHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "MisfitMaid";
+            settings.internalName = "DID/CurrentLapAlways";
+            settings.friendlyName = "Lap counter (always)";
+            return settings;
         }
 
-        class CurrenCheckpointHandler : LaneProvider {
-            LaneProviderSettings@ getProviderSetup() {
-                LaneProviderSettings settings;
-                settings.author = "MisfitMaid";
-                settings.internalName = "DID/CurrentCheckpoint";
-                settings.friendlyName = "Checkpoint counter";
-                return settings;
-            }
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
 
-            LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
-                LaneConfig c = defaults;
-                const MLFeed::HookRaceStatsEventsBase_V3@ mlf = MLFeed::GetRaceData_V3();
-                const MLFeed::PlayerCpInfo_V3@ plf = mlf.GetPlayer_V3(MLFeed::LocalPlayersName);
-                if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
-
-                c.content = Text::Format("%d", plf.CpCount % (mlf.CpCount+1))+" / "+Text::Format("%d", mlf.CpCount);
-                return c;
-            }
+            c.content = Text::Format("%d", (plf.CpCount / (mlf.CpCount+1))+1)+" / "+Text::Format("%d", mlf.LapCount);
+            return c;
         }
+    }
+
+    class CurrenCheckpointHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "MisfitMaid";
+            settings.internalName = "DID/CurrentCheckpoint";
+            settings.friendlyName = "Checkpoint counter";
+            return settings;
+        }
+
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned) return defaults;
+            c.content = Text::Format("%d", plf.CpCount % (mlf.CpCount+1))+" / "+Text::Format("%d", mlf.CpCount);
+            return c;
+        }
+    }
+
+    class NoRespawnTimeHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "XertroV";
+            settings.internalName = "DID/NoRespawnTime";
+            settings.friendlyName = "No-Respawn Time";
+            return settings;
+        }
+
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned || plf.TimeLostToRespawns == 0) return defaults;
+            c.content = Time::Format(plf.TheoreticalRaceTime);
+            return c;
+        }
+    }
+
+    class NoRespawnSplitsHandler : LaneProvider {
+        LaneProviderSettings@ getProviderSetup() {
+            LaneProviderSettings settings;
+            settings.author = "XertroV";
+            settings.internalName = "DID/NoRespawnSplits";
+            settings.friendlyName = "No-Respawn Splits vs Personal Best";
+            return settings;
+        }
+
+        LaneConfig@ getLaneConfig(LaneConfig@ &in defaults) {
+            LaneConfig c = defaults;
+            if (plf is null) return c;
+            if (plf.spawnStatus == MLFeed::SpawnStatus::NotSpawned || plf.TimeLostToRespawns == 0) return defaults;
+            auto cpMs = int(plf.BestRaceTimes[plf.cpCount-1]) - plf.LastTheoreticalCpTime;
+            if ((plf.TheoreticalRaceTime - plf.LastTheoreticalCpTime) < int(deltaTimeDuration))
+                PrepareConfigCpSplitsTime(cpMs, c);
+            return c;
+        }
+    }
 
 }
 #endif

--- a/Settings.as
+++ b/Settings.as
@@ -74,7 +74,7 @@ string LineL1 = "DID/NullProvider";
 string LineL2 = "DID/NullProvider";
 
 [Setting category="Information" hidden]
-string LineL3 = 
+string LineL3 =
 #if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
 	"DID/CurrentLap";
 #else
@@ -82,7 +82,7 @@ string LineL3 =
 #endif
 
 [Setting category="Information" hidden]
-string LineL4 = 
+string LineL4 =
 #if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
 	"DID/CurrentCheckpoint";
 #else
@@ -90,13 +90,23 @@ string LineL4 =
 #endif
 
 [Setting category="Information" hidden]
-string LineR1 = "DID/NullProvider";
+string LineR1 =
+#if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
+	"DID/NoRespawnSplits";
+#else
+	"DID/NullProvider";
+#endif
 
 [Setting category="Information" hidden]
-string LineR2 = "DID/NullProvider";
+string LineR2 =
+#if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
+	"DID/NoRespawnTime";
+#else
+	"DID/NullProvider";
+#endif
 
 [Setting category="Information" hidden]
-string LineR3 = 
+string LineR3 =
 #if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
 	"DID/SplitDelta";
 #else
@@ -104,7 +114,7 @@ string LineR3 =
 #endif
 
 [Setting category="Information" hidden]
-string LineR4 = 
+string LineR4 =
 #if DEPENDENCY_MLFEEDRACEDATA && DEPENDENCY_MLHOOK
 	"DID/RaceTimeSplit";
 #else
@@ -155,11 +165,11 @@ string friendlyDropdownName(DID::LaneProviderSettings settings) {
 void RenderSettingsHelp()
 {
 	UI::TextWrapped("DID is currently in early development. If you encounter any issues or have a feature request, please reach out so that I can get it taken care of! :)");
-	
+
 	UI::Separator();
-	
+
 	UI::TextWrapped("If you are interested in supporting this project or just want to say hi, please consider taking a look at the below links "+Icons::Heart);
-	
+
 	UI::Markdown(Icons::Patreon + " [https://patreon.com/MisfitMaid](https://patreon.com/MisfitMaid)");
 	UI::Markdown(Icons::Paypal + " [https://paypal.me/MisfitMaid](https://paypal.me/MisfitMaid)");
 	UI::Markdown(Icons::Github + " [https://github.com/sylae/DiegeticInfoDisplay](https://github.com/sylae/DiegeticInfoDisplay)");


### PR DESCRIPTION
Add no-respawn timer and no-respawn splits lane providers and set as defaults when MLFeed is present